### PR TITLE
Update julia1_nopil.py

### DIFF
--- a/01_profiling/cpu_profiling/julia1_nopil.py
+++ b/01_profiling/cpu_profiling/julia1_nopil.py
@@ -51,7 +51,7 @@ def calc_pure_python(draw_output, desired_width, max_iterations):
     output = calculate_z_serial_purepython(max_iterations, zs, cs)
     end_time = time.time()
     secs = end_time - start_time
-    print calculate_z_serial_purepython.func_name + " took", secs, "seconds"
+    print calculate_z_serial_purepython.__name__ + " took", secs, "seconds"
 
     # this sum is expected for 1000^2 grid with 300 iterations
     assert sum(output) == 33219980


### PR DESCRIPTION
Using **name** is the preferred method as it applies uniformly. Unlike func_name, it works on built-in functions as well.
Also the double underscores indicate to the reader this is a special attribute. As a bonus, classes and modules have a **name** attribute too, so you only have remember one special name.
