### PR TITLE
Update docstring for julia1.py

### DIFF
--- a/01_profiling/cpu_profiling/julia1.py
+++ b/01_profiling/cpu_profiling/julia1.py
@@ -1,4 +1,4 @@
-"""Julia set generator without optional PIL-based image drawing"""
+"""Julia set generator with optional Pillow-based image drawing"""
 import time
 from PIL import Image
 import array


### PR DESCRIPTION
Fixed the doc string.  This version of the file _includes_ the optional image drawing.  But, the code only works if you use the Pillow fork of PIL.  The latest official PIL release (1.1.7) does not have the `Image.frombytes` method invoked here!
