### PR TITLE
using try-except to check existence of profile

### DIFF
--- a/01_profiling/noop_profile_decorator/ex.py
+++ b/01_profiling/noop_profile_decorator/ex.py
@@ -1,17 +1,15 @@
 import unittest
 
 #import pdb; pdb.set_trace()
-# bit of a hack to check
-# if 1) __builtin__ exists (for when using nosetests)
-# or 2) if 'profile' has been injected by line_profiler
 # if '__builtin__' not in dir() or not hasattr(__builtin__, 'profile'):
 # def profile(func):
 # def inner(*args, **kwargs):
 # return func(*args, **kwargs)
 # return inner
 
-# memory profile
-if 'profile' not in dir():
+try:
+    profile
+except NameError:
     def profile(func):
         def inner(*args, **kwargs):
             return func(*args, **kwargs)


### PR DESCRIPTION
In my environment, `kernprof -l -v 01_profiling/noop_profile_decorator/ex.py` does not show any  profile result because `dir()` does not include `profile` and then (noop)profile decorator should be defined.
I modified the code to catch `NameError` in order to check existence of profile decorator, and it works.
### my environment

```
$ kernprof --version
kernprof 1.0b2

$ python --version
Python 2.7.12 :: Anaconda custom (x86_64)
```
