### PR TITLE
docs: Fix a few typos

### DIFF
--- a/10_clusters/primes/README.md
+++ b/10_clusters/primes/README.md
@@ -2,7 +2,7 @@
 primes.py - basic code to show prime calculation
 primes_timed.py - show how long each call to test n takes, plots blue/red output
 primes_processes.py - control nbr processes and size of data blocks that are sent to control execution speed
-primes2.py - show that checking for even nbrs helps, steping by 2 is a big improvement, only dereference the external library once, move the sqrt until after the early exit
+primes2.py - show that checking for even nbrs helps, stepping by 2 is a big improvement, only dereference the external library once, move the sqrt until after the early exit
 primes_queue1.py - use a Process and a Queue to send work out
 primes_queue2.py - use a map_async (not a map) and a Queue to distribute work
 

--- a/11_less_ram/getsizeof/asizeof.py
+++ b/11_less_ram/getsizeof/asizeof.py
@@ -163,7 +163,7 @@ Notes
        C typedef of digit used in multi-precision int (or long)
        objects.  The size of digit in bytes can be obtained in
        Python from the int (or long) __itemsize__ attribute.
-       Function  leng (rather _len_int) below deterimines the
+       Function  leng (rather _len_int) below determines the
        number of digits from the int (or long) value.
 
    [4] These definitions and other assumptions are rather arbitrary
@@ -2134,7 +2134,7 @@ _asizer = Asizer()
 
 def asized(*objs, **opts):
     '''Return a tuple containing an  Asized instance for each
-       object passed as positional argment using the following
+       object passed as positional argument using the following
        options.
 
            align=8       -- size alignment
@@ -2171,7 +2171,7 @@ def asized(*objs, **opts):
 
 def asizeof(*objs, **opts):
     '''Return the combined size in bytes of all objects passed
-       as positional argments.
+       as positional arguments.
 
        The available options and defaults are the following.
 
@@ -2244,7 +2244,7 @@ def asizeof(*objs, **opts):
 
 def asizesof(*objs, **opts):
     '''Return a tuple containing the size in bytes of all objects
-       passed as positional argments using the following options.
+       passed as positional arguments using the following options.
 
            align=8       -- size alignment
            all=False     -- use GC objects and referents


### PR DESCRIPTION
There are small typos in:
- 10_clusters/primes/README.md
- 11_less_ram/getsizeof/asizeof.py

Fixes:
- Should read `arguments` rather than `argments`.
- Should read `stepping` rather than `steping`.
- Should read `determines` rather than `deterimines`.
- Should read `argument` rather than `argment`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md